### PR TITLE
Refactor CalculateHybridSimilarity to Accept SimilarityOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ A Go client library to calculate similarity between two strings
 go get -u github.com/Ojelaidi/similigo
 ```
 
+
+#### Example
+```go
+package main
+
+import "github.com/Ojelaidi/similigo"
+
+func main() {
+	options := similigo.SimilarityOptions{
+		NgramSize:         3,
+		WordSimWeight:     0.5,
+		NgramSimWeight:    0.3,
+		ContainmentWeight: 0.2,
+	}
+
+	result := similigo.CalculateHybridSimilarity("text1", "text2", &options)
+	fmt.Printf("Similarity Score: %.2f\n", result)
+}
+
+```
+
 ## How to Contribute
 
 If you want to contribute you can read [Contributing](CONTRIBUTING.md)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,25 @@ import (
 	"strings"
 )
 
+// SimilarityOptions represents optional settings for hybrid similarity calculation.
+// - NgramSize: The n-gram size used for n-gram similarity calculation.
+// - WordSimWeight: Weight for word similarity in the final score.
+// - NgramSimWeight: Weight for n-gram similarity in the final score.
+// - ContainmentSimWeight: Weight for containment similarity in the final score.
+type SimilarityOptions struct {
+	NgramSize            int
+	WordSimWeight        float64
+	NgramSimWeight       float64
+	ContainmentSimWeight float64
+}
+
+const (
+	DefaultNgramSize            = 3
+	DefaultWordSimWeight        = 0.5
+	DefaultNgramSimWeight       = 0.3
+	DefaultContainmentSimWeight = 0.2
+)
+
 func getFrequencyMap(text string) map[string]int {
 	freqMap := make(map[string]int)
 	tokens := strings.Fields(strings.ToLower(text))
@@ -151,17 +170,39 @@ func containmentSimilarity(text1, text2 string) float64 {
 // Parameters:
 // - text1: The first text string for comparison.
 // - text2: The second text string for comparison.
-// - n: The n-gram size used for n-gram similarity calculation.
-// - wordSimWeight: Weight for word similarity in the final score.
-// - ngramSimWeight: Weight for n-gram similarity in the final score.
-// - containmentSimWeight: Weight for containment similarity in the final score.
+// - options: An optional struct that allows customization of n-gram size and weights.
 //
 // Returns:
 // The hybrid similarity score, which is a weighted combination of the three similarity measures.
-func CalculateHybridSimilarity(text1, text2 string, n int, wordSimWeight, ngramSimWeight, containmentSimWeight float64) float64 {
+func CalculateHybridSimilarity(text1, text2 string, options *SimilarityOptions) float64 {
+	if options == nil {
+		options = &SimilarityOptions{
+			NgramSize:            DefaultNgramSize,
+			WordSimWeight:        DefaultWordSimWeight,
+			NgramSimWeight:       DefaultNgramSimWeight,
+			ContainmentSimWeight: DefaultContainmentSimWeight,
+		}
+	}
+
+	if options.NgramSize == 0 {
+		options.NgramSize = DefaultNgramSize
+	}
+
+	if options.WordSimWeight == 0.0 {
+		options.WordSimWeight = DefaultWordSimWeight
+	}
+
+	if options.NgramSimWeight == 0.0 {
+		options.NgramSimWeight = DefaultNgramSimWeight
+	}
+
+	if options.ContainmentSimWeight == 0.0 {
+		options.ContainmentSimWeight = DefaultContainmentSimWeight
+	}
+
 	wordSim := cosineSimilarity(text1, text2)
-	ngramSim := ngramCosineSimilarity(text1, text2, n)
+	ngramSim := ngramCosineSimilarity(text1, text2, options.NgramSize)
 	containmentSim := containmentSimilarity(text1, text2)
 
-	return wordSimWeight*wordSim + ngramSimWeight*ngramSim + containmentSimWeight*containmentSim
+	return options.WordSimWeight*wordSim + options.NgramSimWeight*ngramSim + options.ContainmentSimWeight*containmentSim
 }


### PR DESCRIPTION
## Description
This pull request introduces changes to CalculateHybridSimilarity function. It refactors the function to accept a SimilarityOptions struct.

## Changes Made
- [x] Refactored the CalculateHybridSimilarity function to accept an optional SimilarityOptions struct.
- [x] Introduced default values for n-gram size and similarity weights when not provided.
- [x] Updated documentation to reflect the changes.